### PR TITLE
Back-end: setup API ports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem "rack-cors"
+gem 'rack-cors'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,11 +98,6 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.11.0)
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
-      railties (>= 3.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -141,6 +136,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4)
@@ -214,9 +211,9 @@ DEPENDENCIES
   database_cleaner
   debug
   dotenv-rails
-  factory_girl_rails
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.4)
   rspec-rails (~> 6.0.0)
   tzinfo-data

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
In this part of the project, we:

- Installed the 'rack-cors' gem.
- Set up the config/initializers/cors.rb file.

This configuration allows you to use whatever port you want. Just initialize your server with the command 'rails s -p {PORT}', for instance:

    rails s -p 3001

It will work on the address http://localhost:3001/api/v1/bikes. I haven't tested it on other ports but I assume it will work just as fine.

This way, you can work on port 3001 for your rails app, and use the 3000 port for your react app.

The fetching is done as you would do with any other endpoint:

    const fetchModelsAsync = createAsyncThunk(
      FETCH_BIKES_MODELS,
      async () => {
        const response = await fetch(http://localhost:3001/api/v1/bikes);
        const output = await response.json();
        return output;
      },
    );

Remember that your rails server needs to be running all the time when fetching from your react app.

These videos were very helpful with the process:

- [Video 1](https://www.youtube.com/watch?v=k1HjmeqF0p0). Just watch the first 5 minutes of this one.
- [Video 2](https://www.youtube.com/watch?v=sh4WrNGDvQM).
